### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/An0n-00/IT-Ticket/security/code-scanning/3](https://github.com/An0n-00/IT-Ticket/security/code-scanning/3)

The fix involves adding a `permissions` block to the workflow to explicitly limit the `GITHUB_TOKEN` permissions to the minimum required for the task. In this case, the workflow primarily involves checking out code, setting up Node.js, installing dependencies, and running build checks. These operations only require `contents: read` permissions because they do not involve modifying repository contents or interacting with issues or pull requests. The `permissions` key will be added at the root level of the workflow file to apply the restriction to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
