### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/An0n-00/IT-Ticket/security/code-scanning/1](https://github.com/An0n-00/IT-Ticket/security/code-scanning/1)

To fix the issue, we will add a `permissions` key at the workflow root level to apply the least privileges required for all jobs. Since the workflow involves actions such as checking out the repository, building, and testing the code, we can safely start with `contents: read`, which provides the necessary access for reading the repository content without allowing modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
